### PR TITLE
build(docker): optimize images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mv /app/src/demented/build/libs/*-boot.jar app.jar \
 
 FROM ghcr.io/theborakompanioni/java-healthcheck:master@sha256:fba2caf06a8b1f324d18485dbf9389f435b9972ec5fa772f56c012ee9bb77c44 AS healthcheck
 
-FROM openjdk:21-jdk-slim@sha256:7072053847a8a05d7f3a14ebc778a90b38c50ce7e8f199382128a53385160688
+FROM azul/zulu-openjdk-alpine:21-jre-headless@sha256:c3312be85fb542362ac000df1112475dee65ad87021269a6a980f2c7fe9ea536
 
 RUN addgroup --system --gid 1000 app \
   && adduser --system --uid 1000 --ingroup app --disabled-password app

--- a/devel.Dockerfile
+++ b/devel.Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/theborakompanioni/java-healthcheck:master@sha256:fba2caf06a8b1f324d18485dbf9389f435b9972ec5fa772f56c012ee9bb77c44 AS healthcheck
 
-FROM openjdk:21-jdk-slim@sha256:7072053847a8a05d7f3a14ebc778a90b38c50ce7e8f199382128a53385160688
+FROM azul/zulu-openjdk-alpine:21-jre-headless@sha256:c3312be85fb542362ac000df1112475dee65ad87021269a6a980f2c7fe9ea536
+
 ARG JAR_FILE=demented/build/libs/*-boot.jar
 COPY ${JAR_FILE} app.jar
 

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -1,11 +1,10 @@
 services:
 
   app:
-    restart: no
-    container_name: demented_devel_app
     build:
       context: .
       dockerfile: ./devel.Dockerfile
+    restart: no
     depends_on:
       postgres:
         condition: service_healthy
@@ -25,9 +24,10 @@ services:
       --logging.level.web=INFO
 
   postgres:
-    restart: no
-    container_name: demented_devel_db
     image: postgres:17.3-alpine3.21@sha256:80d3d7d6bb3ddb1e44b79612330f7bfc6c451f093f6dd14a1317e777a260b602
+    restart: no
+    labels:
+      org.springframework.boot.ignore: true
     volumes:
       - postgres-data:/postgresql_data
       - ./docker/regtest/pg/data/pg/init:/docker-entrypoint-initdb.d/

--- a/docker/regtest/pg/docker-compose.yml
+++ b/docker/regtest/pg/docker-compose.yml
@@ -1,14 +1,13 @@
 
 services:
   postgres:
-    restart: always
-    container_name: demented_db
     image: postgres:17.3-alpine3.21@sha256:80d3d7d6bb3ddb1e44b79612330f7bfc6c451f093f6dd14a1317e777a260b602
+    restart: unless-stopped
+    labels:
+      org.springframework.boot.ignore: true
     volumes:
       - postgres-data:/postgresql_data
       - ./data/pg/init:/docker-entrypoint-initdb.d/
-    labels:
-      org.springframework.boot.ignore: true
     environment:
       POSTGRES_ADDITIONAL_DATABASES: regtest_nostr_relay0
       POSTGRES_USER: postgres
@@ -25,7 +24,6 @@ services:
 
   pgadmin:
     image: dpage/pgadmin4:9.0.0@sha256:1b2f1ecb93ed2c20530703f77acdfa0da8c2470a4e17044504057cea2d6b4fac
-    container_name: demented_pgadmin
     restart: unless-stopped
     volumes:
       - pgadmin-data:/var/lib/pgadmin

--- a/justfile
+++ b/justfile
@@ -88,7 +88,7 @@ start-jar:
 [group("docker")]
 docker-build:
     @echo "Creating a docker image ..."
-    @docker buildx build -t "$DOCKER_IMAGE_NAME":"$DOCKER_IMAGE_VERSION" .
+    @docker buildx build --load --tag "$DOCKER_IMAGE_NAME":"$DOCKER_IMAGE_VERSION" .
 
 # size of the docker image
 [group("docker")]

--- a/versions.gradle
+++ b/versions.gradle
@@ -16,7 +16,7 @@ ext {
     springdocOpenApiVersion = '2.3.0'
     checkstyleVersion = '10.3.4'
     findsecbugsPluginVersion = '1.12.0'
-    springBootGradlePluginVersion = '3.4.0'
+    springBootGradlePluginVersion = '3.4.4'
     springBootVersion = springBootGradlePluginVersion
     springShellVersion = '3.3.3'
     protobufGradleVersion = '0.9.4'

--- a/versions.gradle
+++ b/versions.gradle
@@ -20,7 +20,7 @@ ext {
     springBootVersion = springBootGradlePluginVersion
     springShellVersion = '3.3.3'
     protobufGradleVersion = '0.9.4'
-    nostrSpringBootStarterVersion = '0.2.0'
+    nostrSpringBootStarterVersion = '0.3.0'
 }
 
 // hack: 2021-11-10T00:00Z - change this timestamp to invalidate GitHub Actions gradle caches.


### PR DESCRIPTION
Base image `azul/zulu-openjdk-alpine:21-jre-headless`: https://hub.docker.com/layers/azul/zulu-openjdk-alpine/21-jre-headless/images/sha256-a8c56514fc11ed33240640019d74eae64894d9d90e420ee380a2b2b359f4a7d7