### PR TITLE
fix: correctly handle events without tags in tag filter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- fix: correctly handle events without tags in tag filter
+
 ## [0.1.0] - 2025-04-10
 ### Added
 - Initial release

--- a/demented/src/integTest/java/org/tbk/nostr/demented/NostrRelaySpecTest.java
+++ b/demented/src/integTest/java/org/tbk/nostr/demented/NostrRelaySpecTest.java
@@ -539,10 +539,11 @@ class NostrRelaySpecTest {
 
         Event eventMatching = MoreEvents.finalize(signer0, Nip1.createTextNote(signer0.getPublicKey(), "GM")
                 .addTags(MoreTags.p(signer0.getPublicKey())));
-        Event eventNonMatching = MoreEvents.finalize(signer1, Nip1.createTextNote(signer1.getPublicKey(), "GM")
+        Event eventNonMatching0 = MoreEvents.finalize(signer1, Nip1.createTextNote(signer1.getPublicKey(), "GM")
                 .addTags(MoreTags.p(signer1.getPublicKey())));
+        Event eventNonMatching1EmptyTags = MoreEvents.finalize(signer0, Nip1.createTextNote(signer1.getPublicKey(), "GM"));
 
-        List<Event> events = List.of(eventMatching, eventNonMatching);
+        List<Event> events = List.of(eventMatching, eventNonMatching0, eventNonMatching1EmptyTags);
         List<OkResponse> oks = nostrTemplate.send(events)
                 .collectList()
                 .blockOptional(Duration.ofSeconds(5))

--- a/demented/src/integTest/java/org/tbk/nostr/demented/NostrRelaySpecTest.java
+++ b/demented/src/integTest/java/org/tbk/nostr/demented/NostrRelaySpecTest.java
@@ -1,7 +1,6 @@
 package org.tbk.nostr.demented;
 
 import com.google.protobuf.ByteString;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -792,6 +791,50 @@ class NostrRelaySpecTest {
         assertThat(fetchedEvents.get(0), is(event1Newer));
         assertThat(fetchedEvents.get(1), is(event0));
         assertThat(fetchedEvents.get(2), is(event2Older));
+    }
+
+    @Test
+    void itShouldFetchEventsWithoutTagsWithMultiFilterWithTags() {
+        Signer signer = SimpleSigner.random();
+
+        Event event0 = MoreEvents.finalize(signer, Nip1.createTextNote(signer.getPublicKey(), "GM"));
+        Event event1Newer = MoreEvents.finalize(signer, event0.toBuilder().setCreatedAt(event0.getCreatedAt() + 1));
+        Event event2Older = MoreEvents.finalize(signer, event0.toBuilder().setCreatedAt(event0.getCreatedAt() - 1));
+
+        List<Event> events = List.of(event0, event1Newer, event2Older);
+        List<OkResponse> oks = nostrTemplate.send(events)
+                .collectList()
+                .blockOptional(Duration.ofSeconds(5))
+                .orElseThrow();
+        assertThat(oks.stream().filter(OkResponse::getSuccess).count(), is((long) events.size()));
+
+        // one filter matches event, others do not match... should return first event
+        Filter matchingFilter = Filter.newBuilder()
+                .addIds(event0.getId())
+                .build();
+
+        Filter.Builder nonMatchingFilter0 = Filter.newBuilder(matchingFilter)
+                .addAuthors(ByteString.copyFrom(SimpleSigner.random().getPublicKey().value.toByteArray()));
+
+        Filter.Builder nonMatchingFilter1 = Filter.newBuilder(matchingFilter)
+                .addAuthors(ByteString.copyFrom(SimpleSigner.random().getPublicKey().value.toByteArray()))
+                .addTags(TagFilter.newBuilder()
+                        .setName(IndexedTag.e.name())
+                        .addValues(EventId.of(event0.getId()).toHex())
+                        .build());
+
+        List<Event> fetchedEvents = nostrTemplate.fetchEvents(ReqRequest.newBuilder()
+                        .setId(MoreSubscriptionIds.random().getId())
+                        .addFilters(nonMatchingFilter0)
+                        .addFilters(matchingFilter)
+                        .addFilters(nonMatchingFilter1)
+                        .build())
+                .collectList()
+                .blockOptional(Duration.ofSeconds(5))
+                .orElseThrow();
+
+        assertThat(fetchedEvents, hasSize(1));
+        assertThat(fetchedEvents.get(0), is(event0));
     }
 
     @RepeatedTest(5)

--- a/demented/src/main/java/org/tbk/nostr/demented/domain/event/EventEntitySpecifications.java
+++ b/demented/src/main/java/org/tbk/nostr/demented/domain/event/EventEntitySpecifications.java
@@ -5,6 +5,7 @@ import com.google.protobuf.Descriptors;
 import fr.acinq.bitcoin.ByteVector32;
 import fr.acinq.bitcoin.XonlyPublicKey;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import org.springframework.data.jpa.domain.Specification;
 import org.tbk.nostr.base.EventId;
 import org.tbk.nostr.base.EventUri;
@@ -106,7 +107,7 @@ public final class EventEntitySpecifications {
 
     public static Specification<EventEntity> hasTagWithFirstValue(IndexedTag tagName, @Nullable String firstTagValue) {
         return (root, query, criteriaBuilder) -> {
-            Join<TagEntity, EventEntity> eventTags = root.join("tags");
+            Join<TagEntity, EventEntity> eventTags = root.join("tags", JoinType.LEFT);
             return criteriaBuilder.and(
                     criteriaBuilder.equal(eventTags.get("name"), tagName.name()),
                     firstTagValue == null ? criteriaBuilder.isNull(eventTags.get("value0")) : criteriaBuilder.equal(eventTags.get("value0"), firstTagValue)

--- a/demented/src/main/resources/application-development.yml
+++ b/demented/src/main/resources/application-development.yml
@@ -13,4 +13,4 @@ logging.level.org.tbk.nostr.demented.domain.event: TRACE
 spring.datasource.url: 'jdbc:sqlite:demented-dev.db?foreign_keys=true&journal_mode=WAL&synchronous=OFF&temp_store=MEMORY&page_size=32768&mmap_size=30000000000'
 
 spring.jpa.properties.hibernate.format_sql: true
-spring.jpa.properties.hibernate.show_sql: false
+spring.jpa.properties.hibernate.show_sql: true

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -61,3 +61,4 @@ services:
 
 volumes:
   postgres-data:
+  pgadmin-data:

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -45,5 +45,19 @@ services:
       timeout: 5s
       retries: 10
 
+  pgadmin:
+    image: dpage/pgadmin4:9.0.0@sha256:1b2f1ecb93ed2c20530703f77acdfa0da8c2470a4e17044504057cea2d6b4fac
+    restart: no
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: postgres@example.org
+      PGADMIN_DEFAULT_PASSWORD: postgres
+    ports:
+      - "15532:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   postgres-data:

--- a/justfile
+++ b/justfile
@@ -63,14 +63,14 @@ package:
 
 # start the app
 [group("development")]
-start:
+start profiles='development':
     #!/usr/bin/env bash
     declare -r JVM_ARGS="-XX:+UseZGC -XX:+ZGenerational"
-    ./gradlew bootRun -Dspring-boot.run.jvmArguments="$JVM_ARGS"
+    SPRING_PROFILES_ACTIVE={{profiles}} ./gradlew bootRun -Dspring-boot.run.jvmArguments="$JVM_ARGS"
 
 # start the app via its packaged jar (requires 'package' step)
 [group("development")]
-start-jar:
+start-jar profiles='development':
     #!/usr/bin/env bash
     APP_JAR="{{build_dir}}/app.jar"
     if [ ! -f "$APP_JAR" ]; then
@@ -82,7 +82,7 @@ start-jar:
         echo "If you want to recompile the uber jar, run \`./gradlew bootJar\` (or \`just package\`) manually."
     fi
     declare -r JVM_ARGS="-XX:+UseZGC -XX:+ZGenerational"
-    java $JVM_ARGS -jar "$APP_JAR" -Dspring.profiles.active=development
+    java $JVM_ARGS -jar "$APP_JAR" -Dspring.profiles.active={{profiles}}
 
 # create a docker image
 [group("docker")]


### PR DESCRIPTION
Before this PR, queries with tag filter have not returned events with empty tags.
After this PR is applied, such events are correctly handled and returned.